### PR TITLE
Handle documented options array

### DIFF
--- a/src/Wp/WpCliDb.php
+++ b/src/Wp/WpCliDb.php
@@ -102,7 +102,7 @@ final class WpCliDb implements Db {
 	public function query( $query, array $sql_arguments = [] ) {
 
 		$arguments = $this->concatArguments(
-            ['query', escapeshellarg((string)$query)],
+			[ 'query', (string) $query ],
 			$sql_arguments
 			// Todo: handle $sql_arguments
 		);

--- a/src/Wp/WpCliDb.php
+++ b/src/Wp/WpCliDb.php
@@ -142,8 +142,8 @@ final class WpCliDb implements Db {
 		try {
 			$arguments = $this->concatArguments(
 				[ 'tables' ],
-				$tables
-				// Todo: handle $options
+				$tables,
+                $this->buildOptions( $options )
 			);
 			$result = $this->wp_cli->run( $arguments );
 			return $this->parseList( $result );
@@ -163,4 +163,24 @@ final class WpCliDb implements Db {
 
 		return array_merge( [ 'db' ], ...$arguments );
 	}
+
+    private function buildOptions( array $options ) {
+
+        $arguments = [];
+
+        $flags = [
+            'scope' => '--scope',
+            'network' => '--network',
+            'all_tables' => '--all-tables',
+            'all_tables_with_prefix' => '--all-tables-with-prefix',
+        ];
+        foreach ( $flags as $flag => $argument ) {
+            if ( empty( $options[ $flag ] ) ) {
+                continue;
+            }
+            true === $options[ $flag ] and $arguments[] = $argument;
+        }
+
+        return $arguments;
+    }
 }

--- a/src/Wp/WpCliDb.php
+++ b/src/Wp/WpCliDb.php
@@ -102,7 +102,7 @@ final class WpCliDb implements Db {
 	public function query( $query, array $sql_arguments = [] ) {
 
 		$arguments = $this->concatArguments(
-			[ 'query', (string) $query ],
+            ['query', escapeshellarg((string)$query)],
 			$sql_arguments
 			// Todo: handle $sql_arguments
 		);


### PR DESCRIPTION
Add a private function (shamelessly copied from the `WpCliSearchReplace` class) to actually process the options array with the keys documented in the docblock.